### PR TITLE
Update for compatibility with core 0.15.0

### DIFF
--- a/bistro.opam
+++ b/bistro.opam
@@ -27,7 +27,9 @@ depends: [
   "base64"
   "bos"
   "dune" {> "1.6"}
-  "core" {>= "0.12.0"}
+  "core" {>= "0.14.0"}
+  "core_kernel" {>= "0.14.0"}
+  "core_unix" {>= "0.14.0"}
   "lwt" {>= "3.2.0"}
   "lwt_react"
   "ocamlgraph" {>= "1.8.7"}

--- a/dune-project
+++ b/dune-project
@@ -33,7 +33,9 @@ Features:
     base64
     bos
     (dune (> 1.6))
-    (core (>= 0.12.0))
+    (core (>= 0.14.0))
+    (core_kernel (>= 0.14.0))
+    (core_unix (>= 0.14.0))
     (lwt (>= 3.2.0))
     lwt_react
     (ocamlgraph (>= 1.8.7))

--- a/lib/engine/db.ml
+++ b/lib/engine/db.ml
@@ -2,6 +2,8 @@
    dir, like aa/aa545 *)
 open Core
 open Rresult
+module Sys = Sys_unix
+module Unix = Core_unix
 
 type id = string
 

--- a/lib/engine/dune
+++ b/lib/engine/dune
@@ -1,4 +1,4 @@
 (library
   (name bistro_engine)
   (public_name bistro.engine)
-  (libraries bistro bos core lwt.unix re rresult))
+  (libraries bistro bos core core_kernel core_unix core_unix.sys_unix lwt.unix re rresult))

--- a/lib/engine/local_backend.ml
+++ b/lib/engine/local_backend.ml
@@ -1,6 +1,7 @@
 open Core
 open Lwt.Infix
 open Bistro_internals
+module Unix = Core_unix
 
 type t = {
   logger : Logger.t ;
@@ -57,7 +58,7 @@ let eval _ () f x =
       (fun () ->
          let ic = Lwt_io.of_unix_fd ~mode:Lwt_io.input read_from_child in
          Lwt_io.read_value ic >>= fun (res : (unit, string) result) ->
-         Caml.Unix.kill (Pid.to_int pid) Caml.Sys.sigkill;
+         Caml_unix.kill (Pid.to_int pid) Caml.Sys.sigkill;
          Misc.waitpid (Pid.to_int pid) >>= fun _ ->
          Unix.close read_from_child ;
          Unix.close write_to_child ;

--- a/lib/engine/misc.ml
+++ b/lib/engine/misc.ml
@@ -1,4 +1,6 @@
 open Core
+module Sys = Sys_unix
+module Unix = Core_unix
 
 let digest x =
   Md5.to_hex (Md5.digest_string (Marshal.to_string x []))

--- a/lib/engine/path.ml
+++ b/lib/engine/path.ml
@@ -1,4 +1,5 @@
 open Core_kernel
+module Sys = Caml.Sys
 
 type t = string list
 [@@deriving sexp]

--- a/lib/engine/scheduler.ml
+++ b/lib/engine/scheduler.ml
@@ -1,6 +1,8 @@
 open Core
 open Lwt.Infix
 open Bistro_internals
+module Sys = Sys_unix
+module Unix = Core_unix
 module W = Bistro_internals.Workflow
 
 type error = [

--- a/lib/engine/shell_command.ml
+++ b/lib/engine/shell_command.ml
@@ -1,5 +1,7 @@
 open Core
 open Bistro_internals
+module Sys = Sys_unix
+module Unix = Core_unix
 
 type file_dump = File_dump of {
     text : string ;

--- a/lib/utils/console_logger.ml
+++ b/lib/utils/console_logger.ml
@@ -1,6 +1,8 @@
 open Core
 open Lwt
 open Bistro_engine
+module Time = Time_unix
+module Unix = Core_unix
 
 let zone = Lazy.force Time.Zone.local
 

--- a/lib/utils/dune
+++ b/lib/utils/dune
@@ -1,5 +1,5 @@
 (library
   (name bistro_utils)
   (public_name bistro.utils)
-  (libraries base64 bistro.engine ocamlgraph tyxml)
+  (libraries base64 bistro.engine core_unix.time_unix ocamlgraph tyxml)
   (preprocess (pps ppx_bistro)))

--- a/lib/utils/html_logger.ml
+++ b/lib/utils/html_logger.ml
@@ -1,6 +1,8 @@
 open Core
 open Bistro_internals
 open Bistro_engine
+module Time = Time_unix
+module Unix = Core_unix
 
 type time = float
 

--- a/lib/utils/repo.ml
+++ b/lib/utils/repo.ml
@@ -2,6 +2,8 @@ open Lwt.Infix
 open Core
 open Bistro
 open Bistro_engine
+module Sys = Sys_unix
+module Unix = Core_unix
 
 module W = Bistro_internals.Workflow
 


### PR DESCRIPTION
Core is now platform-independent, and Core_kernel is no more.  The
Unix-dependent parts have been moved to a separate package, core_unix.

In this PR, I elected to just bump the version of core so that there would be no deprecation warnings from using Core_kernel.  I can rewrite this to instead try to be compatible with both 0.14 and 0.15, if you prefer, but core_unix was only introduced in 0.14 so there won't be a way to be compatible with both 0.13 and 0.15 at the same time, for example.