### PR TITLE
Update getting-started.rst

### DIFF
--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -45,7 +45,7 @@ is a nice interactive interpreter for OCaml:
 
 .. code:: sh
 
-   $ opam install bistro utop
+   $ opam install bistro bistro-bio utop
 
 If you're new to OCaml, you might want to install ``ocaml-top``, which
 is a simple editor supporting syntax highlighting, automatic


### PR DESCRIPTION
bistro no longer depends on bistro-bio, so it has to be explicitly installed.